### PR TITLE
feat: 勤務時間計算APIの実装

### DIFF
--- a/app/app/Http/Controllers/Api/WorkTimeController.php
+++ b/app/app/Http/Controllers/Api/WorkTimeController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\CalculateWorkTimeRequest;
+use App\Http\Responses\WorkTimeResponse;
+use App\Services\WorkTimeCalculationService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @OA\Info(
+ *     title="Work Time Calculation API",
+ *     version="1.0.0",
+ *     description="勤務時間計算API"
+ * )
+ */
+class WorkTimeController extends Controller
+{
+    /**
+     * @OA\Post(
+     *     path="/api/calculate-work-time",
+     *     summary="勤務時間計算",
+     *     description="開始時刻、終了時刻、休憩時間から勤務時間を計算します",
+     *     tags={"Work Time"},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"start_time","end_time","break_time"},
+     *             @OA\Property(property="start_time", type="string", example="09:00", description="開始時刻（HH:MM形式）"),
+     *             @OA\Property(property="end_time", type="string", example="28:00", description="終了時刻（HH:MM形式、日またぎ可）"),
+     *             @OA\Property(property="break_time", type="string", example="01:00", description="休憩時間（HH:MM形式）"),
+     *             @OA\Property(property="rounding_unit", type="integer", nullable=true, example=null, description="丸め単位（分）")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="成功時のレスポンス",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="hours", type="integer", example=19, description="勤務時間（時間単位）"),
+     *             @OA\Property(property="minutes", type="integer", example=0, description="勤務時間（分単位）"),
+     *             @OA\Property(property="total_minutes", type="integer", example=1140, description="勤務時間の合計（分）")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="バリデーションエラー",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="The given data was invalid."),
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     )
+     * )
+     */
+    public function calculateWorkTime(CalculateWorkTimeRequest $request): JsonResponse
+    {
+        try {
+            // バリデーション済みデータを取得
+            $validated = $request->validated();
+
+            // サービスクラスを使用して計算
+            $service = new WorkTimeCalculationService();
+            $result = $service->calculateWorkTime(
+                $validated['start_time'],
+                $validated['end_time'],
+                $validated['break_time'],
+                $validated['rounding_unit'] ?? null
+            );
+
+            return new WorkTimeResponse($result['hours'], $result['minutes'], $result['total_minutes']);
+
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => '計算処理中にエラーが発生しました。',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
+
+
+}
+

--- a/app/app/Http/Requests/CalculateWorkTimeRequest.php
+++ b/app/app/Http/Requests/CalculateWorkTimeRequest.php
@@ -3,11 +3,13 @@
 namespace App\Http\Requests;
 
 use App\Rules\TimeFormat;
+use App\Rules\EndTimeFormat;
 use App\Rules\BreakTimeFormat;
 use App\Services\WorkTimeCalculationService;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Symfony\Component\HttpFoundation\Response;
 
 class CalculateWorkTimeRequest extends FormRequest
 {
@@ -25,9 +27,9 @@ class CalculateWorkTimeRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'start_time' => ['required', new TimeFormat()],
-            'end_time' => ['required', new TimeFormat()],
-            'break_time' => ['required', new BreakTimeFormat()],
+            'start_time' => ['required', new TimeFormat()],      // 00:00～23:59
+            'end_time' => ['required', new EndTimeFormat()],     // 00:01～48:00
+            'break_time' => ['required', new BreakTimeFormat()], // 00:00～23:59
             'rounding_unit' => ['nullable', 'integer', 'min:1', 'max:60'],
         ];
     }
@@ -87,7 +89,7 @@ class CalculateWorkTimeRequest extends FormRequest
             response()->json([
                 'message' => '入力値が正しくありません。',
                 'errors' => $validator->errors()
-            ], 422)
+            ], Response::HTTP_UNPROCESSABLE_ENTITY) // 422 Unprocessable Entity
         );
     }
 
@@ -96,7 +98,7 @@ class CalculateWorkTimeRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
-        // 時刻データの正規化（必要に応じて）
+        // 時刻データの正規化
         $this->merge([
             'start_time' => trim($this->input('start_time', '')),
             'end_time' => trim($this->input('end_time', '')),

--- a/app/app/Http/Requests/CalculateWorkTimeRequest.php
+++ b/app/app/Http/Requests/CalculateWorkTimeRequest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\TimeFormat;
+use App\Rules\BreakTimeFormat;
+use App\Services\WorkTimeCalculationService;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class CalculateWorkTimeRequest extends FormRequest
+{
+    /**
+     * リクエストの認可を決定
+     */
+    public function authorize(): bool
+    {
+        return true; // 認証不要
+    }
+
+    /**
+     * バリデーションルール
+     */
+    public function rules(): array
+    {
+        return [
+            'start_time' => ['required', new TimeFormat()],
+            'end_time' => ['required', new TimeFormat()],
+            'break_time' => ['required', new BreakTimeFormat()],
+            'rounding_unit' => ['nullable', 'integer', 'min:1', 'max:60'],
+        ];
+    }
+
+    /**
+     * カスタムバリデーションメッセージ
+     */
+    public function messages(): array
+    {
+        return [
+            'start_time.required' => '開始時刻は必須です。',
+            'end_time.required' => '終了時刻は必須です。',
+            'break_time.required' => '休憩時間は必須です。',
+            'rounding_unit.integer' => '丸め単位は整数で入力してください。',
+            'rounding_unit.min' => '丸め単位は1分以上で入力してください。',
+            'rounding_unit.max' => '丸め単位は60分以下で入力してください。',
+        ];
+    }
+
+    /**
+     * カスタムバリデーション
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function ($validator) {
+            $this->validateTimeLogic($validator);
+        });
+    }
+
+    /**
+     * 時刻の論理的な整合性をチェック
+     */
+    private function validateTimeLogic(Validator $validator): void
+    {
+        $startTime = $this->input('start_time');
+        $endTime = $this->input('end_time');
+        $breakTime = $this->input('break_time');
+
+        if (!$startTime || !$endTime || !$breakTime) {
+            return; // 基本バリデーションでエラーになるため、ここではスキップ
+        }
+
+        $service = new WorkTimeCalculationService();
+        $errors = $service->validateTimeLogic($startTime, $endTime, $breakTime);
+
+        foreach ($errors as $error) {
+            $validator->errors()->add('time_logic', $error);
+        }
+    }
+
+    /**
+     * バリデーション失敗時のレスポンス
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'message' => '入力値が正しくありません。',
+                'errors' => $validator->errors()
+            ], 422)
+        );
+    }
+
+    /**
+     * リクエストデータの前処理
+     */
+    protected function prepareForValidation(): void
+    {
+        // 時刻データの正規化（必要に応じて）
+        $this->merge([
+            'start_time' => trim($this->input('start_time', '')),
+            'end_time' => trim($this->input('end_time', '')),
+            'break_time' => trim($this->input('break_time', '')),
+            'rounding_unit' => $this->input('rounding_unit') ? intval($this->input('rounding_unit')) : null,
+        ]);
+    }
+}

--- a/app/app/Http/Responses/WorkTimeResponse.php
+++ b/app/app/Http/Responses/WorkTimeResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+
+class WorkTimeResponse extends JsonResponse
+{
+    /**
+     * WorkTimeResponse コンストラクタ
+     *
+     * @param  int  $hours  勤務時間（時間単位）
+     * @param  int  $minutes  勤務時間（分単位）
+     * @param  int  $totalMinutes  勤務時間の合計（分）
+     * @param  int  $status  HTTPステータスコード
+     * @param  array  $headers  HTTPヘッダー
+     * @param  int  $options  JSONエンコードオプション
+     */
+    public function __construct(int $hours, int $minutes, int $totalMinutes, int $status = 200, array $headers = [], int $options = 0)
+    {
+        $data = [
+            'hours' => $hours,
+            'minutes' => $minutes,
+            'total_minutes' => $totalMinutes
+        ];
+        parent::__construct($data, $status, $headers, $options);
+    }
+}
+

--- a/app/app/Rules/BreakTimeFormat.php
+++ b/app/app/Rules/BreakTimeFormat.php
@@ -9,6 +9,7 @@ class BreakTimeFormat implements ValidationRule
 {
     /**
      * バリデーションを実行
+     * 休憩時間用：00:00～23:59
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -17,18 +18,25 @@ class BreakTimeFormat implements ValidationRule
             return;
         }
 
-        // 休憩時間は通常の時刻形式のみ（00:00～23:59）
+        // 時刻形式チェック（HH:MM）
         if (!preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
             $fail('正しい時刻形式（HH:MM）で入力してください。');
             return;
         }
 
-        // 休憩時間が24時間を超える場合は無効
+        // 範囲チェック（00:00～23:59）
         $parts = explode(':', $value);
         $hours = intval($parts[0]);
-        
-        if ($hours >= 24) {
-            $fail('休憩時間は24時間未満で入力してください。');
+        $minutes = intval($parts[1]);
+
+        if ($hours < 0 || $hours > 23) {
+            $fail('休憩時間は00:00～23:59の範囲で入力してください。');
+            return;
+        }
+
+        if ($minutes < 0 || $minutes > 59) {
+            $fail('分は00～59の範囲で入力してください。');
+            return;
         }
     }
 }

--- a/app/app/Rules/BreakTimeFormat.php
+++ b/app/app/Rules/BreakTimeFormat.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class BreakTimeFormat implements ValidationRule
+{
+    /**
+     * バリデーションを実行
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!is_string($value)) {
+            $fail('休憩時間は文字列で入力してください。');
+            return;
+        }
+
+        // 休憩時間は通常の時刻形式のみ（00:00～23:59）
+        if (!preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
+            $fail('正しい時刻形式（HH:MM）で入力してください。');
+            return;
+        }
+
+        // 休憩時間が24時間を超える場合は無効
+        $parts = explode(':', $value);
+        $hours = intval($parts[0]);
+        
+        if ($hours >= 24) {
+            $fail('休憩時間は24時間未満で入力してください。');
+        }
+    }
+}

--- a/app/app/Rules/EndTimeFormat.php
+++ b/app/app/Rules/EndTimeFormat.php
@@ -5,11 +5,11 @@ namespace App\Rules;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
-class TimeFormat implements ValidationRule
+class EndTimeFormat implements ValidationRule
 {
     /**
      * バリデーションを実行
-     * 開始時刻用：00:00～23:59
+     * 終了時刻用：00:01～48:00
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
@@ -19,18 +19,31 @@ class TimeFormat implements ValidationRule
         }
 
         // 時刻形式チェック（HH:MM）
-        if (!preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
+        if (!preg_match('/^([01]?[0-9]|2[0-3]|4[0-8]):[0-5][0-9]$/', $value)) {
             $fail('正しい時刻形式（HH:MM）で入力してください。');
             return;
         }
 
-        // 範囲チェック（00:00～23:59）
+        // 範囲チェック（00:01～48:00）
         $parts = explode(':', $value);
         $hours = intval($parts[0]);
         $minutes = intval($parts[1]);
 
-        if ($hours < 0 || $hours > 23) {
-            $fail('時刻は00:00～23:59の範囲で入力してください。');
+        // 00:00は許可しない（最小値は00:01）
+        if ($hours === 0 && $minutes === 0) {
+            $fail('終了時刻は00:01以降で入力してください。');
+            return;
+        }
+
+        // 48:00を超える場合は無効
+        if ($hours > 48) {
+            $fail('終了時刻は48:00までしか設定できません。');
+            return;
+        }
+
+        // 48:00の場合、分は00のみ許可
+        if ($hours === 48 && $minutes > 0) {
+            $fail('48:00を超える時刻は設定できません。');
             return;
         }
 

--- a/app/app/Rules/TimeFormat.php
+++ b/app/app/Rules/TimeFormat.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class TimeFormat implements ValidationRule
+{
+    /**
+     * バリデーションを実行
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!is_string($value)) {
+            $fail('時刻は文字列で入力してください。');
+            return;
+        }
+
+        // 通常の時刻形式（00:00～23:59）
+        if (preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
+            return;
+        }
+
+        // 日またぎ対応時刻形式（24:00～99:59）
+        if (preg_match('/^([2-9][0-9]|1[0-9][0-9]):[0-5][0-9]$/', $value)) {
+            return;
+        }
+
+        $fail('正しい時刻形式（HH:MM）で入力してください。');
+    }
+}

--- a/app/app/Services/WorkTimeCalculationService.php
+++ b/app/app/Services/WorkTimeCalculationService.php
@@ -57,17 +57,7 @@ class WorkTimeCalculationService
         return $baseDate->setTime($hours, $minutes, 0);
     }
 
-    /**
-     * 終了時刻の48:00制限をチェック
-     */
-    private function validateEndTimeLimit(string $endTime): bool
-    {
-        $parts = explode(':', $endTime);
-        $hours = intval($parts[0]);
-        
-        // 48:00を超える場合は無効
-        return $hours <= 48;
-    }
+
 
     /**
      * 勤務時間を計算（分単位）
@@ -106,12 +96,6 @@ class WorkTimeCalculationService
     public function validateTimeLogic(string $startTime, string $endTime, string $breakTime): array
     {
         $errors = [];
-
-        // 終了時刻の48:00制限チェック
-        if (!$this->validateEndTimeLimit($endTime)) {
-            $errors[] = '終了時刻は48:00までしか設定できません。';
-            return $errors; // 制限を超えている場合は他のチェックをスキップ
-        }
 
         // 時刻をCarbonオブジェクトに変換
         $startCarbon = $this->timeStringToCarbon($startTime);

--- a/app/app/Services/WorkTimeCalculationService.php
+++ b/app/app/Services/WorkTimeCalculationService.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+
+class WorkTimeCalculationService
+{
+    /**
+     * 勤務時間を計算
+     */
+    public function calculateWorkTime(string $startTime, string $endTime, string $breakTime, ?int $roundingUnit = null): array
+    {
+        // 時刻をCarbonオブジェクトに変換
+        $startCarbon = $this->timeStringToCarbon($startTime);
+        $endCarbon = $this->timeStringToCarbon($endTime);
+        $breakCarbon = $this->timeStringToCarbon($breakTime);
+
+        // 勤務時間を計算（分単位）
+        $workMinutes = $this->calculateWorkMinutes($startCarbon, $endCarbon, $breakCarbon);
+
+        // 丸め処理
+        if ($roundingUnit !== null) {
+            $workMinutes = $this->roundMinutes($workMinutes, $roundingUnit);
+        }
+
+        // 時間と分に分解
+        $hours = intval($workMinutes / 60);
+        $minutes = $workMinutes % 60;
+
+        return [
+            'hours' => $hours,
+            'minutes' => $minutes,
+            'total_minutes' => $workMinutes
+        ];
+    }
+
+    /**
+     * 時刻文字列をCarbonオブジェクトに変換
+     * 終了時刻は最大48:00まで対応
+     */
+    private function timeStringToCarbon(string $time): Carbon
+    {
+        $parts = explode(':', $time);
+        $hours = intval($parts[0]);
+        $minutes = intval($parts[1]);
+
+        // 基準日を設定（今日の日付）
+        $baseDate = Carbon::today();
+
+        // 24時間を超える場合（日またぎ）の処理
+        if ($hours >= 24) {
+            $hours = $hours - 24;
+            $baseDate = $baseDate->addDay();
+        }
+
+        return $baseDate->setTime($hours, $minutes, 0);
+    }
+
+    /**
+     * 終了時刻の48:00制限をチェック
+     */
+    private function validateEndTimeLimit(string $endTime): bool
+    {
+        $parts = explode(':', $endTime);
+        $hours = intval($parts[0]);
+        
+        // 48:00を超える場合は無効
+        return $hours <= 48;
+    }
+
+    /**
+     * 勤務時間を計算（分単位）
+     */
+    private function calculateWorkMinutes(Carbon $startTime, Carbon $endTime, Carbon $breakTime): int
+    {
+        // 終了時刻が開始時刻より前の場合（日またぎ）
+        if ($endTime->lt($startTime)) {
+            $endTime = $endTime->addDay();
+        }
+
+        // 総労働時間を計算（分単位）
+        $totalMinutes = $startTime->diffInMinutes($endTime);
+        
+        // 休憩時間を分に変換
+        $breakMinutes = $breakTime->hour * 60 + $breakTime->minute;
+
+        // 勤務時間を計算
+        $workMinutes = $totalMinutes - $breakMinutes;
+
+        // 負の値にならないように調整
+        return max(0, $workMinutes);
+    }
+
+    /**
+     * 分を指定単位で丸める
+     */
+    private function roundMinutes(int $minutes, int $roundingUnit): int
+    {
+        return round($minutes / $roundingUnit) * $roundingUnit;
+    }
+
+    /**
+     * 時刻の論理的な整合性をチェック
+     */
+    public function validateTimeLogic(string $startTime, string $endTime, string $breakTime): array
+    {
+        $errors = [];
+
+        // 終了時刻の48:00制限チェック
+        if (!$this->validateEndTimeLimit($endTime)) {
+            $errors[] = '終了時刻は48:00までしか設定できません。';
+            return $errors; // 制限を超えている場合は他のチェックをスキップ
+        }
+
+        // 時刻をCarbonオブジェクトに変換
+        $startCarbon = $this->timeStringToCarbon($startTime);
+        $endCarbon = $this->timeStringToCarbon($endTime);
+        $breakCarbon = $this->timeStringToCarbon($breakTime);
+
+        // 終了時刻が開始時刻より前の場合（日またぎ）
+        if ($endCarbon->lt($startCarbon)) {
+            $endCarbon = $endCarbon->addDay();
+        }
+
+        // 総労働時間を計算（分単位）
+        $totalWorkMinutes = $startCarbon->diffInMinutes($endCarbon);
+        
+        // 休憩時間を分に変換
+        $breakMinutes = $breakCarbon->hour * 60 + $breakCarbon->minute;
+
+        // 休憩時間が総労働時間を超えている場合
+        if ($breakMinutes > $totalWorkMinutes) {
+            $errors[] = '休憩時間が総労働時間を超えています。';
+        }
+
+        // 勤務時間が負になる場合
+        $actualWorkMinutes = $totalWorkMinutes - $breakMinutes;
+        if ($actualWorkMinutes < 0) {
+            $errors[] = '勤務時間が負になります。終了時刻を調整してください。';
+        }
+
+        return $errors;
+    }
+}

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\PlaygroundController;
+use App\Http\Controllers\Api\WorkTimeController;
 use Illuminate\Support\Facades\Route;
 
 // ルート定義
@@ -9,3 +10,6 @@ Route::prefix('playground')->controller(PlaygroundController::class)->group(func
     Route::get('/buggy-continue-level-example', 'buggyContinueLevelExample');
     Route::get('/correct-continue-level-example', 'correctContinueLevelExample');
 });
+
+// 勤務時間計算API
+Route::post('/calculate-work-time', [WorkTimeController::class, 'calculateWorkTime']);


### PR DESCRIPTION
## 概要
勤務時間を自動計算するAPIを実装しました。開始時刻、終了時刻、休憩時間から勤務時間を算出し、日またぎ勤務にも対応しています。

## ✨ 新機能
- **勤務時間計算API** (`POST /api/calculate-work-time`)
- 開始時刻: 00:00～23:59
- 終了時刻: 00:01～48:00（最大2日間対応）
- 休憩時間: 00:00～23:59
- 丸め処理対応（任意）

## 実装内容

### アーキテクチャ
- **Form Request**: バリデーション専用クラス
- **Service**: ビジネスロジック分離
- **Custom Rules**: 時刻形式のカスタムバリデーション
- **Carbon**: 安全な日付・時刻処理

## 技術仕様

### レスポンス形式
```json
{
    "hours": 8,
    "minutes": 30,
    "total_minutes": 510
}
```
