### PR TITLE
fix: 終了時刻バリデーションの正規表現修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ toolbox api は、Laravelを使用して構築されたWebアプリケーショ�
 <!-- - ユーザー登録画面: http://localhost/register -->
 <!-- - ログイン画面: http://localhost/login -->
 <!-- - APIエンドポイント一覧は `docs/api.md` を参照 -->
-OpenAIドキュメント:http://localhost:8088/api/documentation  
+OpenAIドキュメント:http://localhost:8089/api/documentation  
 
 ## 開発ルール
 - ブランチ運用ルール
   - `main`: 本番用
   - `develop`: 開発用
   - `feature/xxx`: 新機能開発用
+  - `fix/xxx`: バグ修正用
+  - `chore/xxx`: 保守作業用
 - コードフォーマット
   - pint を使用（`vendor/bin/pint`）
   - larastan を使用（`vendor/bin/phpstan analyse --memory-limit=1G`）

--- a/app/app/Http/Controllers/Api/PlaygroundController.php
+++ b/app/app/Http/Controllers/Api/PlaygroundController.php
@@ -21,10 +21,13 @@ class PlaygroundController extends Controller
      *     summary="サンプルAPI",
      *     description="これはお試し用のサンプルAPIです。",
      *     tags={"Playground"},
+     *
      *     @OA\Response(
      *         response=200,
      *         description="成功時のレスポンス",
+     *
      *         @OA\JsonContent(
+     *
      *             @OA\Property(property="message", type="string", example="This is a sample API response.")
      *         )
      *     )

--- a/app/app/Http/Controllers/Api/WorkTimeController.php
+++ b/app/app/Http/Controllers/Api/WorkTimeController.php
@@ -23,29 +23,38 @@ class WorkTimeController extends Controller
      *     summary="勤務時間計算",
      *     description="開始時刻、終了時刻、休憩時間から勤務時間を計算します",
      *     tags={"Work Time"},
+     *
      *     @OA\RequestBody(
      *         required=true,
+     *
      *         @OA\JsonContent(
      *             required={"start_time","end_time","break_time"},
+     *
      *             @OA\Property(property="start_time", type="string", example="09:00", description="開始時刻（HH:MM形式）"),
      *             @OA\Property(property="end_time", type="string", example="28:00", description="終了時刻（HH:MM形式、日またぎ可）"),
      *             @OA\Property(property="break_time", type="string", example="01:00", description="休憩時間（HH:MM形式）"),
      *             @OA\Property(property="rounding_unit", type="integer", nullable=true, example=null, description="丸め単位（分）")
      *         )
      *     ),
+     *
      *     @OA\Response(
      *         response=200,
      *         description="成功時のレスポンス",
+     *
      *         @OA\JsonContent(
+     *
      *             @OA\Property(property="hours", type="integer", example=19, description="勤務時間（時間単位）"),
      *             @OA\Property(property="minutes", type="integer", example=0, description="勤務時間（分単位）"),
      *             @OA\Property(property="total_minutes", type="integer", example=1140, description="勤務時間の合計（分）")
      *         )
      *     ),
+     *
      *     @OA\Response(
      *         response=422,
      *         description="バリデーションエラー",
+     *
      *         @OA\JsonContent(
+     *
      *             @OA\Property(property="message", type="string", example="The given data was invalid."),
      *             @OA\Property(property="errors", type="object")
      *         )
@@ -59,7 +68,7 @@ class WorkTimeController extends Controller
             $validated = $request->validated();
 
             // サービスクラスを使用して計算
-            $service = new WorkTimeCalculationService();
+            $service = new WorkTimeCalculationService;
             $result = $service->calculateWorkTime(
                 $validated['start_time'],
                 $validated['end_time'],
@@ -72,11 +81,8 @@ class WorkTimeController extends Controller
         } catch (\Exception $e) {
             return response()->json([
                 'message' => '計算処理中にエラーが発生しました。',
-                'error' => $e->getMessage()
+                'error' => $e->getMessage(),
             ], 500);
         }
     }
-
-
 }
-

--- a/app/app/Http/Requests/CalculateWorkTimeRequest.php
+++ b/app/app/Http/Requests/CalculateWorkTimeRequest.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Requests;
 
-use App\Rules\TimeFormat;
-use App\Rules\EndTimeFormat;
 use App\Rules\BreakTimeFormat;
+use App\Rules\EndTimeFormat;
+use App\Rules\TimeFormat;
 use App\Services\WorkTimeCalculationService;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,9 +27,9 @@ class CalculateWorkTimeRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'start_time' => ['required', new TimeFormat()],      // 00:00～23:59
-            'end_time' => ['required', new EndTimeFormat()],     // 00:01～48:00
-            'break_time' => ['required', new BreakTimeFormat()], // 00:00～23:59
+            'start_time' => ['required', new TimeFormat],      // 00:00～23:59
+            'end_time' => ['required', new EndTimeFormat],     // 00:01～48:00
+            'break_time' => ['required', new BreakTimeFormat], // 00:00～23:59
             'rounding_unit' => ['nullable', 'integer', 'min:1', 'max:60'],
         ];
     }
@@ -68,11 +68,11 @@ class CalculateWorkTimeRequest extends FormRequest
         $endTime = $this->input('end_time');
         $breakTime = $this->input('break_time');
 
-        if (!$startTime || !$endTime || !$breakTime) {
+        if (! $startTime || ! $endTime || ! $breakTime) {
             return; // 基本バリデーションでエラーになるため、ここではスキップ
         }
 
-        $service = new WorkTimeCalculationService();
+        $service = new WorkTimeCalculationService;
         $errors = $service->validateTimeLogic($startTime, $endTime, $breakTime);
 
         foreach ($errors as $error) {
@@ -88,7 +88,7 @@ class CalculateWorkTimeRequest extends FormRequest
         throw new HttpResponseException(
             response()->json([
                 'message' => '入力値が正しくありません。',
-                'errors' => $validator->errors()
+                'errors' => $validator->errors(),
             ], Response::HTTP_UNPROCESSABLE_ENTITY) // 422 Unprocessable Entity
         );
     }

--- a/app/app/Http/Responses/WorkTimeResponse.php
+++ b/app/app/Http/Responses/WorkTimeResponse.php
@@ -21,9 +21,8 @@ class WorkTimeResponse extends JsonResponse
         $data = [
             'hours' => $hours,
             'minutes' => $minutes,
-            'total_minutes' => $totalMinutes
+            'total_minutes' => $totalMinutes,
         ];
         parent::__construct($data, $status, $headers, $options);
     }
 }
-

--- a/app/app/Rules/BreakTimeFormat.php
+++ b/app/app/Rules/BreakTimeFormat.php
@@ -13,14 +13,16 @@ class BreakTimeFormat implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             $fail('休憩時間は文字列で入力してください。');
+
             return;
         }
 
         // 時刻形式チェック（HH:MM）
-        if (!preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
+        if (! preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
             $fail('正しい時刻形式（HH:MM）で入力してください。');
+
             return;
         }
 
@@ -31,11 +33,13 @@ class BreakTimeFormat implements ValidationRule
 
         if ($hours < 0 || $hours > 23) {
             $fail('休憩時間は00:00～23:59の範囲で入力してください。');
+
             return;
         }
 
         if ($minutes < 0 || $minutes > 59) {
             $fail('分は00～59の範囲で入力してください。');
+
             return;
         }
     }

--- a/app/app/Rules/EndTimeFormat.php
+++ b/app/app/Rules/EndTimeFormat.php
@@ -13,14 +13,16 @@ class EndTimeFormat implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             $fail('時刻は文字列で入力してください。');
+
             return;
         }
 
         // 時刻形式チェック（HH:MM）
-        if (!preg_match('/^([01]?[0-9]|2[0-3]|4[0-8]):[0-5][0-9]$/', $value)) {
+        if (! preg_match('/^([0123]?[0-9]|4[0-8]):[0-5][0-9]$/', $value)) {
             $fail('正しい時刻形式（HH:MM）で入力してください。');
+
             return;
         }
 
@@ -32,23 +34,27 @@ class EndTimeFormat implements ValidationRule
         // 00:00は許可しない（最小値は00:01）
         if ($hours === 0 && $minutes === 0) {
             $fail('終了時刻は00:01以降で入力してください。');
+
             return;
         }
 
         // 48:00を超える場合は無効
         if ($hours > 48) {
             $fail('終了時刻は48:00までしか設定できません。');
+
             return;
         }
 
         // 48:00の場合、分は00のみ許可
         if ($hours === 48 && $minutes > 0) {
             $fail('48:00を超える時刻は設定できません。');
+
             return;
         }
 
         if ($minutes < 0 || $minutes > 59) {
             $fail('分は00～59の範囲で入力してください。');
+
             return;
         }
     }

--- a/app/app/Rules/TimeFormat.php
+++ b/app/app/Rules/TimeFormat.php
@@ -13,14 +13,16 @@ class TimeFormat implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             $fail('時刻は文字列で入力してください。');
+
             return;
         }
 
         // 時刻形式チェック（HH:MM）
-        if (!preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
+        if (! preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/', $value)) {
             $fail('正しい時刻形式（HH:MM）で入力してください。');
+
             return;
         }
 
@@ -31,11 +33,13 @@ class TimeFormat implements ValidationRule
 
         if ($hours < 0 || $hours > 23) {
             $fail('時刻は00:00～23:59の範囲で入力してください。');
+
             return;
         }
 
         if ($minutes < 0 || $minutes > 59) {
             $fail('分は00～59の範囲で入力してください。');
+
             return;
         }
     }

--- a/app/app/Services/WorkTimeCalculationService.php
+++ b/app/app/Services/WorkTimeCalculationService.php
@@ -31,7 +31,7 @@ class WorkTimeCalculationService
         return [
             'hours' => $hours,
             'minutes' => $minutes,
-            'total_minutes' => $workMinutes
+            'total_minutes' => $workMinutes,
         ];
     }
 
@@ -57,8 +57,6 @@ class WorkTimeCalculationService
         return $baseDate->setTime($hours, $minutes, 0);
     }
 
-
-
     /**
      * 勤務時間を計算（分単位）
      */
@@ -71,7 +69,7 @@ class WorkTimeCalculationService
 
         // 総労働時間を計算（分単位）
         $totalMinutes = $startTime->diffInMinutes($endTime);
-        
+
         // 休憩時間を分に変換
         $breakMinutes = $breakTime->hour * 60 + $breakTime->minute;
 
@@ -109,7 +107,7 @@ class WorkTimeCalculationService
 
         // 総労働時間を計算（分単位）
         $totalWorkMinutes = $startCarbon->diffInMinutes($endCarbon);
-        
+
         // 休憩時間を分に変換
         $breakMinutes = $breakCarbon->hour * 60 + $breakCarbon->minute;
 

--- a/app/tests/Feature/PlaygroundApiTest.php
+++ b/app/tests/Feature/PlaygroundApiTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class PlaygroundApiTest extends TestCase

--- a/docs/setup/swagger.md
+++ b/docs/setup/swagger.md
@@ -59,7 +59,7 @@ public function sample(): JsonResponse
 `storage/api-docs/api-docs.json` が生成される
 
 ## Swagger にアクセス確認
-http://localhost:8088/api/documentation  
+http://localhost:8089/api/documentation  
 ドキュメントが表示される
 
 # darkaonline/l5-swaggerの説明


### PR DESCRIPTION
## 修正内容
- 24:00～39:59の時刻に対応するよう正規表現を修正
- コード整形を実行（Pint）

## 修正詳細
- 正規表現パターンを `[0123]?[0-9]|4[0-8]` に最適化
- 00:01～48:00の範囲を正確に検証